### PR TITLE
Tell make to use bash as its shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY = default deps build test start clean start-database
 
+SHELL := /bin/bash
 IMAGE_NAME := codelytv/typescript-ddd-skeleton
 SERVICE_NAME := app
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY = default deps build test start clean start-database
 
-SHELL := /bin/bash
+# Shell to use for running scripts
+SHELL := $(shell which bash)
 IMAGE_NAME := codelytv/typescript-ddd-skeleton
 SERVICE_NAME := app
 


### PR DESCRIPTION
Executing make with ZSH shows `make: command: Command not found `, if BASH is a dependency then it could be a good idea to explicitly tell that to make.
for more info: [my question in stackoverflow](https://stackoverflow.com/questions/62721593/what-that-this-line-means-in-a-make-file-docker-shell-command-v-docker/62723364#62723364)