### PR TITLE
Docker image based on node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.3-slim
+FROM node:14-slim
 
 WORKDIR /code
 


### PR DESCRIPTION
I saw in the latest commit a bump in the node version to start using v14, but the docker image was based on 12.
